### PR TITLE
feat: enable to set all consul's configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ tests/_roles
 
 # Node.js
 node_modules
+
+# git-rm-branch
+# https://github.com/suzuki-shunsuke/git-rm-branch
+.git-rm-branch.yml

--- a/README.md
+++ b/README.md
@@ -18,16 +18,12 @@ name | required | default | example | description
 --- | --- | --- | --- | ---
 consul_arch | yes | | linux_amd64, darwin_amd64, etc |
 consul_version | yes | | 0.9.2 | installed binary version
-consul_start_join | no | not specified | ["192.168.33.10"] | [start_join](https://www.consul.io/docs/agent/options.html#start_join)
 consul_lib_dir | no | /usr/local/lib | | The install path. This directory is generated if it doesn't exist
 consul_bin_dir | no | /usr/local/bin | | The install path. This directory is generated if it doesn't exist
-consul_data_dir | no | /tmp/consul | | [-data-dir](https://www.consul.io/docs/agent/options.html#_data_dir). This directory is generated if it doesn't exist
 consul_config_file | no | /etc/consul/consul.json | | [-config-file](https://www.consul.io/docs/agent/options.html#_config_file). This parent directory is generated if it doesn't exist
-consul_bootstrap_expect | no | not specified | | [-bootstrap-expect](https://www.consul.io/docs/agent/options.html#_bootstrap_expect)
-consul_node | no | `ansible_hostname` | | [-node](https://www.consul.io/docs/agent/options.html#_node)
-consul_is_server | no | no | yes | [-server](https://www.consul.io/docs/agent/options.html#_server)
 consul_enabled | no | undefined (do nothing) | yes/no | whether consul service is enabled
-consul_bind | no | `ansible_default_ipv4.address` | "192.168.60.10" | [-bind](https://www.consul.io/docs/agent/options.html#_bind)
+consul_config | no | {} | |
+consul_default_config | no | see [defaults/main.yml](defaults/main.yml) | |
 
 ## Dependencies
 
@@ -40,18 +36,19 @@ consul_bind | no | `ansible_default_ipv4.address` | "192.168.60.10" | [-bind](ht
   roles:
   - role: suzuki-shunsuke.consul
     consul_arch: linux_amd64
-    consul_version: 0.9.2
-    consul_start_join:
-    - 192.168.33.10
-    - 192.168.33.11
+    consul_version: 0.9.3
     consul_lib_dir: "{{ansible_env.HOME}}/lib"
     consul_bin_dir: "{{ansible_env.HOME}}/bin"
-    consul_data_dir: /tmp/consul
     consul_config_file: /etc/consul/consul.json
-    consul_bootstrap_expect: 3
-    consul_node: "{{ansible_hostname}}"
-    consul_is_server: yes
     consul_enabled: yes
+    consul_config:
+      start_join:
+        - 192.168.33.10
+        - 192.168.33.11
+      bootstrap_expect: 3
+      node_name: "{{ansible_hostname}}"
+      server: true
+      data_dir: /tmp/consul
 ```
 
 ## Change Log

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@ consul_bin_dir: /usr/local/bin
 consul_lib_dir: /usr/local/lib
 consul_data_dir: /tmp/consul
 consul_config_file: /etc/consul/consul.json
-consul_node: "{{ansible_hostname}}"
-consul_bind: "{{ansible_default_ipv4.address}}"
-consul_is_server: no
+consul_default_config:
+  node_name: "{{ansible_hostname}}"
+  bind_addr: "{{ansible_default_ipv4.address}}"
+  server: false
+consul_config: {}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,17 +6,17 @@ galaxy_info:
   github_branch: master
 
   platforms:
-  - name: EL
-    versions:
-    - 7
+    - name: EL
+      versions:
+        - 7
 
   galaxy_tags:
-  - consul
+    - consul
 
 dependencies:
-- role: suzuki-shunsuke.hashicorp-binary
-  hashicorp_binary_name: consul
-  hashicorp_binary_arch: "{{consul_arch}}"
-  hashicorp_binary_version: "{{consul_version}}"
-  hashicorp_binary_lib_dir: "{{consul_lib_dir}}"
-  hashicorp_binary_bin_dir: "{{consul_bin_dir}}"
+  - role: suzuki-shunsuke.hashicorp-binary
+    hashicorp_binary_name: consul
+    hashicorp_binary_arch: "{{consul_arch}}"
+    hashicorp_binary_version: "{{consul_version}}"
+    hashicorp_binary_lib_dir: "{{consul_lib_dir}}"
+    hashicorp_binary_bin_dir: "{{consul_bin_dir}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,8 +8,9 @@
     path: "{{consul_config_file|dirname}}"
 - name: deploy consul configuration file
   template:
-    src: consul.json
+    src: consul.json.j2
     dest: "{{consul_config_file}}"
+  register: consul_config_file
 - name: deploy consul's service unit file
   template:
     src: consul.service
@@ -21,7 +22,7 @@
     name: consul
     daemon_reload: "{{consul_service_unit.changed}}"
     state: restarted
-  when: consul_service_unit.changed
+  when: consul_config_file.changed or consul_service_unit.changed
 - name: change consul enabled
   systemd:
     name: consul

--- a/templates/consul.json
+++ b/templates/consul.json
@@ -1,7 +1,0 @@
-{% if consul_start_join is defined %}
-{
-  "start_join": {{consul_start_join|to_json}}
-}
-{% else %}
-{}
-{% endif %}

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -1,0 +1,1 @@
+{{consul_default_config|combine(consul_config)|to_json}}

--- a/templates/consul.service
+++ b/templates/consul.service
@@ -5,11 +5,6 @@ After=syslog.target network.target
 [Service]
 Type=simple
 ExecStart={{consul_bin_dir}}/consul agent \
-  {% if consul_is_server %}-server{% endif %} \
-  {% if consul_bootstrap_expect is defined %}-bootstrap-expect={{consul_bootstrap_expect}}{% endif %} \
-  -node={{consul_node}} \
-  -bind={{consul_bind}} \
-  -data-dir={{consul_data_dir}} \
   -config-file={{consul_config_file}}
 ExecReload={{consul_bin_dir}}/consul reload
 ExecStop={{consul_bin_dir}}/consul leave

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -9,4 +9,5 @@ Vagrant.configure(2) do |config|
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "./test.yml"
   end
+  config.vm.synced_folder ".", "/vagrant", disabled: true
 end

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,11 +6,12 @@
     consul_version: 0.9.3
     consul_lib_dir: "{{ansible_env.HOME}}/lib"
     consul_bin_dir: "{{ansible_env.HOME}}/bin"
-    consul_data_dir: /tmp/consul
     consul_config_file: /etc/consul/consul.json
-    consul_node: "consul-1"
-    consul_is_server: yes
     consul_enabled: yes
+    consul_config:
+      data_dir: /tmp/consul
+      node_name: consul-1
+      server: true
     become: "{{(ansible_env.USER is undefined)|ternary(ansible_env.HOME != '/root', ansible_env.USER != 'root')}}"
   tasks:
   - name: check consul version


### PR DESCRIPTION
BREAKING CHANGE: Some variables are removed. Set them in the `consul_config` variable.

* consul_data_dir: consul_config.data_dir
* consul_node: consul_config.node_name
* consul_is_server: consul_config.server
* consul_bind: consul_config.bind_addr
* consul_bootstrap_expect: consul_config.bootstrap_expect